### PR TITLE
Task/fix partneship

### DIFF
--- a/src/pages/admin/dashboard.tsx
+++ b/src/pages/admin/dashboard.tsx
@@ -2,7 +2,7 @@ import { ProjectManager } from '@/presentation/components/pages-components/admin
 import { getServerSideProps } from '@/gssp-admin-cookies'
 import { BlogManager } from '@/presentation/components/pages-components/admin/blog-manager'
 import { CollaboratorManager } from '@/presentation/components/pages-components/admin/collaborator-manager'
-import { PartnershipManager } from '@/presentation/components/pages-components/partnership/partnership-manager'
+import { PartnershipManager } from '@/presentation/components/pages-components/admin/partnership-manager'
 
 function Dashboard() {
   return (

--- a/src/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog.tsx
+++ b/src/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/presentation/components/shadcn-ui/dialog'
+import { Button } from '@/presentation/components/global-components/button'
+
+interface IDeleteConfirmationDialogProps {
+  handleDelete: () => void
+}
+
+function DeleteConfirmationDialog({
+  handleDelete,
+}: IDeleteConfirmationDialogProps) {
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Tem certeza que deseja excluir?</DialogTitle>
+        <DialogDescription>
+          A exclusão é permanente, pense bem antes de realizá-la.
+        </DialogDescription>
+        <DialogFooter className={'flex flex-row gap-1 justify-center p-4'}>
+          <DialogClose asChild>
+            <Button variant={'outline'}>Desistir</Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button variant={'default'} onClick={() => handleDelete()}>
+              Excluir
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogHeader>
+    </DialogContent>
+  )
+}
+
+export default DeleteConfirmationDialog

--- a/src/presentation/components/pages-components/admin/admin-partnership-card.tsx
+++ b/src/presentation/components/pages-components/admin/admin-partnership-card.tsx
@@ -5,12 +5,6 @@ import { queryClient } from '@/infra/lib/use-query/query-client'
 import { useToast } from '@/presentation/hooks/use-toast'
 import {
   Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from '@/presentation/components/shadcn-ui/dialog'
 import { useRouter } from 'next/router'
@@ -18,6 +12,8 @@ import { useState } from 'react'
 import { IGetPartnershipResponse } from '@/domain/api-responses/partnership/get-partnership-response'
 import { deletePartnership } from '@/infra/adapters/partnership/delete-project'
 import EmptyImage from '@/root/public/empty-image.png'
+import DeleteConfirmationDialog from '@/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog'
+
 interface IProps {
   partnership: IGetPartnershipResponse
 }
@@ -101,24 +97,7 @@ export function AdminPartnershipCard({
         </div>
       </div>
 
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Tem certeza que deseja excluir?</DialogTitle>
-          <DialogDescription>
-            A exclusão é permanente, pense bem antes de realizá-la.
-          </DialogDescription>
-          <DialogFooter className={'flex flex-row gap-5 justify-center p-4'}>
-            <DialogClose asChild>
-              <Button variant={'default'} onClick={() => handleDelete()}>
-                Excluir
-              </Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button variant={'outline'}>Desistir</Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogHeader>
-      </DialogContent>
+      <DeleteConfirmationDialog handleDelete={handleDelete} />
     </Dialog>
   )
 }

--- a/src/presentation/components/pages-components/admin/admin-post-card.tsx
+++ b/src/presentation/components/pages-components/admin/admin-post-card.tsx
@@ -3,12 +3,6 @@ import { queryClient } from '@/infra/lib/use-query/query-client'
 import { useToast } from '@/presentation/hooks/use-toast'
 import {
   Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from '@/presentation/components/shadcn-ui/dialog'
 import { useRouter } from 'next/router'
@@ -16,6 +10,7 @@ import { useState } from 'react'
 import { formatPostDescription } from '@/presentation/utils/format-post-description'
 import { SubHeading } from '@/presentation/components/global-components/text/subheading'
 import { deleteBlogPost } from '@/infra/adapters/blog/post/delete-blog-post'
+import DeleteConfirmationDialog from '@/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog'
 
 export function AdminPostCard({ post }: { post: IPost }): JSX.Element {
   const { toast } = useToast()
@@ -103,24 +98,7 @@ export function AdminPostCard({ post }: { post: IPost }): JSX.Element {
         </div>
       </div>
 
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Tem certeza que deseja excluir?</DialogTitle>
-          <DialogDescription>
-            A exclusão é permanente, pense bem antes de realizá-la.
-          </DialogDescription>
-          <DialogFooter className={'flex flex-row gap-5 justify-center p-4'}>
-            <DialogClose asChild>
-              <Button variant={'default'} onClick={() => handleDelete()}>
-                Excluir
-              </Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button variant={'outline'}>Desistir</Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogHeader>
-      </DialogContent>
+      <DeleteConfirmationDialog handleDelete={handleDelete} />
     </Dialog>
   )
 }

--- a/src/presentation/components/pages-components/admin/admin-project-card.tsx
+++ b/src/presentation/components/pages-components/admin/admin-project-card.tsx
@@ -5,17 +5,12 @@ import { queryClient } from '@/infra/lib/use-query/query-client'
 import { useToast } from '@/presentation/hooks/use-toast'
 import {
   Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from '@/presentation/components/shadcn-ui/dialog'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { deleteProject } from '@/infra/adapters/project/delete-project'
+import DeleteConfirmationDialog from '@/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog'
 
 interface IProps {
   project: {
@@ -112,24 +107,7 @@ export function AdminProjectCard({
         </div>
       </div>
 
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Tem Certeza que deseja excluir?</DialogTitle>
-          <DialogDescription>
-            A exclusão é permanente, pense bem antes de realizá-la.
-          </DialogDescription>
-          <DialogFooter className={'flex flex-row gap-5 justify-center p-4'}>
-            <DialogClose asChild>
-              <Button variant={'default'} onClick={() => handleDelete()}>
-                Excluir
-              </Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button variant={'outline'}>Desistir</Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogHeader>
-      </DialogContent>
+      <DeleteConfirmationDialog handleDelete={handleDelete} />
     </Dialog>
   )
 }

--- a/src/presentation/components/pages-components/admin/collaborator-card.tsx
+++ b/src/presentation/components/pages-components/admin/collaborator-card.tsx
@@ -5,18 +5,13 @@ import { queryClient } from '@/infra/lib/use-query/query-client'
 import { useToast } from '@/presentation/hooks/use-toast'
 import {
   Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from '@/presentation/components/shadcn-ui/dialog'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { TextHighlight } from '../../global-components/text/textHighlight'
 import { deleteCollaborator } from '@/infra/adapters/collaborators/delete-collaborator'
+import DeleteConfirmationDialog from '@/presentation/components/global-components/delete-confirmation-dialog/delete-confirmation-dialog'
 
 interface IProps {
   collaborator: {
@@ -112,24 +107,7 @@ export function AdminCollaboratorCard({
         </div>
       </div>
 
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Tem Certeza que deseja excluir?</DialogTitle>
-          <DialogDescription>
-            A exclusão é permanente, pense bem antes de realizá-la.
-          </DialogDescription>
-          <DialogFooter className={'flex flex-row justify-center p-4'}>
-            <DialogClose asChild>
-              <Button variant={'default'} onClick={() => handleDelete()}>
-                Excluir
-              </Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button variant={'outline'}>Desistir</Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogHeader>
-      </DialogContent>
+      <DeleteConfirmationDialog handleDelete={handleDelete} />
     </Dialog>
   )
 }

--- a/src/presentation/components/pages-components/admin/partnership-manager.tsx
+++ b/src/presentation/components/pages-components/admin/partnership-manager.tsx
@@ -13,6 +13,8 @@ export function PartnershipManager() {
     queryFn: () => getPartnerships(5),
   })
 
+  console.log('a')
+
   return (
     <article className={'animate-showing opacity-0 flex flex-col gap-12'}>
       <div
@@ -28,6 +30,13 @@ export function PartnershipManager() {
       <section className={'flex flex-col lg:flex-row justify-start gap-4'}>
         {isLoading &&
           Array.from({ length: 3 }).map(() => <AdminProjectCardSkeleton />)}
+
+        {!partnerships ||
+          (partnerships.length === 0 && (
+            <div className={'text-gray-500 text-sm'}>
+              <p>Você ainda não possui parcerias cadastradas</p>
+            </div>
+          ))}
 
         {partnerships &&
           partnerships.map(

--- a/src/presentation/components/pages-components/admin/partnership-manager.tsx
+++ b/src/presentation/components/pages-components/admin/partnership-manager.tsx
@@ -22,9 +22,9 @@ export function PartnershipManager() {
           'flex flex-col gap-2  justify-between sm:flex-row sm:items-center'
         }
       >
-        <Heading>Gerencie suas parceirias</Heading>
+        <Heading>Gerencie suas parcerias</Heading>
         <Button href={'/admin/partnership/create-partnership'} Icon={Plus}>
-          Criar uma parceiria
+          Criar uma parceria
         </Button>
       </div>
       <section className={'flex flex-col lg:flex-row justify-start gap-4'}>

--- a/src/presentation/components/pages-components/home/partnerships.tsx
+++ b/src/presentation/components/pages-components/home/partnerships.tsx
@@ -11,6 +11,8 @@ export function Partnerships() {
     queryFn: () => getPartnerships(4),
   })
 
+  if (!partnerships || partnerships.length === 0) return <></>
+
   return (
     <article className={'flex flex-col  gap-12'}>
       <Heading>Parcerias que impulsionam resultados!</Heading>


### PR DESCRIPTION
Changelog:

- Lidar com a parceria vazia na home e no dashboard
- Consertar erro de portugues aonde estava escrito "parceirias" para "parcerias"
- Criar um componente "delete-confirmation-dialog" para componentizar o popoup de confirmação de deleção que é utilizado nos componentes do dashboard